### PR TITLE
Add support for RxJava 2

### DIFF
--- a/rxappfocus-sample/build.gradle
+++ b/rxappfocus-sample/build.gradle
@@ -21,6 +21,7 @@ android {
 dependencies {
     implementation project(':rxappfocus')
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    
+    implementation 'io.reactivex:rxjava:1.3.4'
+
     testImplementation 'junit:junit:4.12'
 }

--- a/rxappfocus-sample/build.gradle
+++ b/rxappfocus-sample/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     implementation project(':rxappfocus')
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'io.reactivex:rxjava:1.3.4'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.6'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/rxappfocus-sample/src/main/java/com/example/rxappfocus/App.java
+++ b/rxappfocus-sample/src/main/java/com/example/rxappfocus/App.java
@@ -5,7 +5,7 @@ import android.widget.Toast;
 
 import com.gramboid.rxappfocus.AppFocusProvider;
 
-import rx.functions.Action1;
+import io.reactivex.functions.Consumer;
 
 public class App extends Application {
 
@@ -17,10 +17,10 @@ public class App extends Application {
         focusProvider = new AppFocusProvider(this);
 
         // show a toast every time the app becomes visible or hidden
-        focusProvider.getAppFocus()
-                .subscribe(new Action1<Boolean>() {
+        focusProvider.getAppFocus2()
+                .subscribe(new Consumer<Boolean>() {
                     @Override
-                    public void call(Boolean visible) {
+                    public void accept(Boolean visible) {
                         Toast.makeText(App.this, visible ? "App visible" : "App hidden", Toast.LENGTH_SHORT).show();
                     }
                 });

--- a/rxappfocus-sample/src/main/java/com/example/rxappfocus/MainActivity.java
+++ b/rxappfocus-sample/src/main/java/com/example/rxappfocus/MainActivity.java
@@ -8,13 +8,14 @@ import android.view.View;
 
 import com.gramboid.rxappfocus.AppFocusProvider;
 
-import rx.Subscription;
-import rx.functions.Action1;
-import rx.functions.Func1;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Predicate;
+
 
 public class MainActivity extends AppCompatActivity {
 
-    private Subscription     sub;
+    private Disposable disposable;
     private AppFocusProvider focusProvider;
 
     @Override
@@ -33,16 +34,17 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        sub = focusProvider
-                .getAppFocus()
-                .filter(new Func1<Boolean, Boolean>() {
-                    @Override public Boolean call(Boolean visible) {
+        disposable = focusProvider
+                .getAppFocus2()
+                .filter(new Predicate<Boolean>() {
+                    @Override
+                    public boolean test(Boolean visible) throws Exception {
                         return visible;
                     }
                 })
-                .subscribe(new Action1<Boolean>() {
+                .subscribe(new Consumer<Boolean>() {
                     @Override
-                    public void call(Boolean visible) {
+                    public void accept(Boolean visible) throws Exception {
                         Log.d("MainActivity", "We are visible!");
                     }
                 });
@@ -51,6 +53,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStop() {
         super.onStop();
-        sub.unsubscribe();
+        disposable.dispose();
     }
 }

--- a/rxappfocus/build.gradle
+++ b/rxappfocus/build.gradle
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     api 'com.android.support:support-annotations:26.1.0'
-    api 'io.reactivex:rxjava:1.3.4'
+    compileOnly 'io.reactivex:rxjava:1.3.4'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/rxappfocus/build.gradle
+++ b/rxappfocus/build.gradle
@@ -27,6 +27,7 @@ android {
 dependencies {
     api 'com.android.support:support-annotations:26.1.0'
     compileOnly 'io.reactivex:rxjava:1.3.4'
+    compileOnly 'io.reactivex.rxjava2:rxjava:2.1.6'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
+++ b/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
@@ -85,6 +85,7 @@ public class AppFocusProvider {
     /**
      * Returns an RxJava 1 Observable that emits a Boolean indicating whether the app is currently visible, and again each time the app's visibility changes.
      */
+    @NonNull
     public rx.Observable<Boolean> getAppFocus() {
         return subjectV1;
     }
@@ -92,6 +93,7 @@ public class AppFocusProvider {
     /**
      * Returns an RxJava 2 Observable that emits a Boolean indicating whether the app is currently visible, and again each time the app's visibility changes.
      */
+    @NonNull
     public io.reactivex.Observable<Boolean> getAppFocus2() {
         return subjectV2;
     }

--- a/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
+++ b/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
@@ -14,8 +14,8 @@ import rx.subjects.ReplaySubject;
  */
 public class AppFocusProvider {
 
-    private boolean  changingConfig;
-    private int      foregroundCounter;
+    private boolean changingConfig;
+    private int foregroundCounter;
     private Activity visibleActivity;
 
     private final ReplaySubject<Boolean> appFocusSubject = ReplaySubject.createWithSize(1);
@@ -32,7 +32,7 @@ public class AppFocusProvider {
                 final boolean justBecomingVisible = !isVisible();
                 foregroundCounter++;
                 if (justBecomingVisible) {
-                    appFocusSubject.onNext(true);
+                    publishState(true);
                 }
             }
         }
@@ -45,13 +45,17 @@ public class AppFocusProvider {
             } else {
                 foregroundCounter--;
                 if (!isVisible()) {
-                    appFocusSubject.onNext(false);
+                    publishState(false);
                     visibleActivity = null;
                 }
             }
         }
 
     };
+
+    private void publishState(boolean visible) {
+        appFocusSubject.onNext(visible);
+    }
 
     public AppFocusProvider(@NonNull Application app) {
         app.registerActivityLifecycleCallbacks(callbacks);


### PR DESCRIPTION
This adds support for RxJava 2.

The library now has non-transitive dependencies on RxJava1 and 2, so the consuming project can decide which they want.