### PR TITLE
Add dummy ContentProvider to auto-init

### DIFF
--- a/rxappfocus-sample/src/main/java/com/example/rxappfocus/App.java
+++ b/rxappfocus-sample/src/main/java/com/example/rxappfocus/App.java
@@ -14,7 +14,7 @@ public class App extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        focusProvider = new AppFocusProvider(this);
+        focusProvider = AppFocusProvider.getInstance();
 
         // show a toast every time the app becomes visible or hidden
         focusProvider.getAppFocus2()

--- a/rxappfocus-sample/src/main/java/com/example/rxappfocus/App.java
+++ b/rxappfocus-sample/src/main/java/com/example/rxappfocus/App.java
@@ -9,15 +9,12 @@ import io.reactivex.functions.Consumer;
 
 public class App extends Application {
 
-    private AppFocusProvider focusProvider;
-
     @Override
     public void onCreate() {
         super.onCreate();
-        focusProvider = AppFocusProvider.getInstance();
 
         // show a toast every time the app becomes visible or hidden
-        focusProvider.getAppFocus2()
+        AppFocusProvider.getInstance().getAppFocus2()
                 .subscribe(new Consumer<Boolean>() {
                     @Override
                     public void accept(Boolean visible) {
@@ -26,7 +23,4 @@ public class App extends Application {
                 });
     }
 
-    public AppFocusProvider getFocusProvider() {
-        return focusProvider;
-    }
 }

--- a/rxappfocus-sample/src/main/java/com/example/rxappfocus/MainActivity.java
+++ b/rxappfocus-sample/src/main/java/com/example/rxappfocus/MainActivity.java
@@ -16,13 +16,11 @@ import io.reactivex.functions.Predicate;
 public class MainActivity extends AppCompatActivity {
 
     private Disposable disposable;
-    private AppFocusProvider focusProvider;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        focusProvider = ((App) getApplication()).getFocusProvider();
 
         findViewById(R.id.button_change_activity).setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {
@@ -34,8 +32,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        disposable = focusProvider
-                .getAppFocus2()
+        disposable = AppFocusProvider.getInstance().getAppFocus2()
                 .filter(new Predicate<Boolean>() {
                     @Override
                     public boolean test(Boolean visible) throws Exception {

--- a/rxappfocus/src/main/AndroidManifest.xml
+++ b/rxappfocus/src/main/AndroidManifest.xml
@@ -1,3 +1,10 @@
-<manifest package="com.gramboid.rxappfocus">
-    <application/>
+<manifest package="com.gramboid.rxappfocus"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <provider
+            android:authorities="${applicationId}.rxappfocus.initprovider"
+            android:exported="false"
+            android:enabled="true"
+            android:name=".InitProvider" />
+    </application>
 </manifest>

--- a/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
+++ b/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
@@ -1,8 +1,10 @@
 package com.gramboid.rxappfocus;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -11,6 +13,13 @@ import androidx.annotation.Nullable;
  * Provides Observables to monitor app visibility.
  */
 public class AppFocusProvider {
+
+    @SuppressLint("StaticFieldLeak")
+    private static final AppFocusProvider instance = new AppFocusProvider();
+
+    public static AppFocusProvider getInstance() {
+        return instance;
+    }
 
     private boolean changingConfig;
     private int foregroundCounter;
@@ -80,7 +89,10 @@ public class AppFocusProvider {
         }
     }
 
-    public AppFocusProvider(@NonNull Application app) {
+    private AppFocusProvider() {
+    }
+
+    void init(@NonNull Application app) {
         app.registerActivityLifecycleCallbacks(callbacks);
     }
 
@@ -92,7 +104,7 @@ public class AppFocusProvider {
         if (subjectV1 != null) {
             return subjectV1;
         } else {
-             throw new IllegalStateException("RxJava 1 not found");
+            throw new IllegalStateException("RxJava 1 not found");
         }
     }
 

--- a/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
+++ b/rxappfocus/src/main/java/com/gramboid/rxappfocus/AppFocusProvider.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
  */
 public class AppFocusProvider {
 
+    // This doesn't actually leak the visibleActivity since we null it out
     @SuppressLint("StaticFieldLeak")
     private static final AppFocusProvider instance = new AppFocusProvider();
 

--- a/rxappfocus/src/main/java/com/gramboid/rxappfocus/InitProvider.java
+++ b/rxappfocus/src/main/java/com/gramboid/rxappfocus/InitProvider.java
@@ -1,0 +1,56 @@
+package com.gramboid.rxappfocus;
+
+import android.app.Application;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+
+import androidx.annotation.Nullable;
+
+public final class InitProvider extends ContentProvider {
+
+    public InitProvider() {
+    }
+
+    @Override
+    public boolean onCreate() {
+        Context appContext = getContext().getApplicationContext();
+        if (appContext instanceof Application) {
+            Application app = (Application) appContext;
+            AppFocusProvider.getInstance().init(app);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+}


### PR DESCRIPTION
This auto-initialises the library.

It's a breaking API change since the constructor is no longer public; instead, apps just need to call `AppFocusProvider.getInstance()` to get the static instance of the `AppFocusProvider`.

Fixes #3 